### PR TITLE
day4: replace `fromMaybe`'s lambda with a pointfree expression

### DIFF
--- a/04/main.hs
+++ b/04/main.hs
@@ -40,8 +40,7 @@ diagonals g = [diagonal d g | d <- [-(length g)..length g]]
 
 
 diagonal :: Int -> [String] -> String
--- TODO: find a fancy way of removing the lambda
-diagonal d g = zipWith (\r i -> fromMaybe '.' (r !? i)) g [d..]
+diagonal d g = zipWith ((fromMaybe '.' .) . (!?)) g [d..]
 
 -- Can't use the !? operator from Data.List because my base version is too low
 (!?) :: [a] -> Int -> Maybe a


### PR DESCRIPTION
youtube's deleting my comment because of too many special characters :(

this double `(.)` usage is something i remembered doing before but couldn't test during the stream, i don't think it's neat tho, looking in `Control.Arrow` for a solution is probably better