### PR TITLE
day3: make use of `MonadFail`'s application on unmatched patterns

### DIFF
--- a/03/main.hs
+++ b/03/main.hs
@@ -21,10 +21,8 @@ parseCorruptedMemory part1 toggle s = inner toggle s
             | not ("mul(" `isPrefixOf` s) = inner toggle rest
             | otherwise = fromMaybe (inner toggle rest) $ do
                 guard (part1 || toggle)
-                (n1, c1:rest1) <- tryParseInt (drop 4 s)
-                guard (c1 == ',')
-                (n2, c2:rest2) <- tryParseInt rest1
-                guard (c2 == ')')
+                (n1, ',':rest1) <- tryParseInt (drop 4 s)
+                (n2, ')':rest2) <- tryParseInt rest1
                 return $ (n1 * n2) + inner toggle rest2
           inner _ "" = 0
 
@@ -32,6 +30,6 @@ parseCorruptedMemory part1 toggle s = inner toggle s
 tryParseInt :: String -> Maybe (Int, String)
 tryParseInt s = case span isDigit s of
                     ("", rest) -> Nothing
-                    (n,  rest) -> Just ((read n), rest)
+                    (n,  rest) -> Just (read n, rest)
 
 


### PR DESCRIPTION
TIL if a monad has an implementation of `fail` the do notation runs it on computations whose result doesn't match an expected pattern instead of throwing a non-exhaustive patterns exception. So the code that validates separator characters can be simplified to just pattern matching the separators and if they're not present we'll default to `Nothing` by virtue of `do`